### PR TITLE
revert threadpool

### DIFF
--- a/commons-asyncclient/src/main/scala/com/wajam/asyncclient/AsyncClient.scala
+++ b/commons-asyncclient/src/main/scala/com/wajam/asyncclient/AsyncClient.scala
@@ -63,7 +63,6 @@ sealed trait Request {
 
 class AsyncClient(config: BaseHttpClientConfig) extends BaseAsyncClient {
 
-  // Create a thread-pool of bounded size (given by the configuration) with expiration of idle threads after 60 sec.
   private implicit val ec = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(config.threadPoolSize))
 
   private val httpClient = Http.configure(_.


### PR DESCRIPTION
Revert the thread-pool implementation because the new one does not work well with the default client value.
