### PR TITLE
[COMMONS] Added FutureUtils to help with managing future execution (parallel or in sequential)

### DIFF
--- a/commons-core/src/main/scala/com/wajam/commons/FutureUtils.scala
+++ b/commons-core/src/main/scala/com/wajam/commons/FutureUtils.scala
@@ -15,8 +15,8 @@ object FutureUtils {
    *
    * The first failure will fail the returned Future.
    */
-  def serialize[A, B](elements: Iterable[A], asyncProcessing: A => Future[B])
-                     (implicit ec: ExecutionContext): Future[Iterable[B]] = {
+  def serialize[A, B](elements: Seq[A], asyncProcessing: A => Future[B])
+                     (implicit ec: ExecutionContext): Future[Seq[B]] = {
     serialWithTransform(elements, asyncProcessing, identity[Future[B]])
   }
 
@@ -27,13 +27,13 @@ object FutureUtils {
    * Any success or failure is wrapped in a Try object. The returned Future will contain one Try object per
    * element in the Iterable.
    */
-  def serializeWithRecovery[A, B](elements: Iterable[A], asyncProcessing: A => Future[B])
-                                 (implicit ec: ExecutionContext): Future[Iterable[Try[B]]] = {
+  def serializeWithRecovery[A, B](elements: Seq[A], asyncProcessing: A => Future[B])
+                                 (implicit ec: ExecutionContext): Future[Seq[Try[B]]] = {
     serialWithTransform(elements, asyncProcessing, toFutureOfTry[B])
   }
 
-  def serialWithTransform[A, B, C](elements: Iterable[A], asyncProcessing: A => Future[B], transform: Future[B] => Future[C])
-                                  (implicit ec: ExecutionContext): Future[Iterable[C]] = {
+  def serialWithTransform[A, B, C](elements: Seq[A], asyncProcessing: A => Future[B], transform: Future[B] => Future[C])
+                                  (implicit ec: ExecutionContext): Future[Seq[C]] = {
     import scala.languageFeature.postfixOps
     elements.foldLeft(Future.successful(new ArrayBuffer[C](elements.size))) {
       (previousFuture, e) =>
@@ -47,8 +47,8 @@ object FutureUtils {
    *
    * The first failure will fail the returned Future.
    */
-  def parallel[A, B](elements: Iterable[A], asyncProcessing: A => Future[B])
-                    (implicit ec: ExecutionContext): Future[Iterable[B]] = {
+  def parallel[A, B](elements: Seq[A], asyncProcessing: A => Future[B])
+                    (implicit ec: ExecutionContext): Future[Seq[B]] = {
     parallelWithTransform(elements, asyncProcessing, identity[Future[B]])
   }
 
@@ -59,13 +59,13 @@ object FutureUtils {
    * Any success or failure is wrapped in a Try object. The returned Future will contain one Try object per
    * element in the Iterable.
    */
-  def parallelWithRecovery[A, B](elements: Iterable[A], asyncProcessing: A => Future[B])
-                                (implicit ec: ExecutionContext): Future[Iterable[Try[B]]] = {
+  def parallelWithRecovery[A, B](elements: Seq[A], asyncProcessing: A => Future[B])
+                                (implicit ec: ExecutionContext): Future[Seq[Try[B]]] = {
     parallelWithTransform(elements, asyncProcessing, toFutureOfTry[B])
   }
 
-  def parallelWithTransform[A, B, C](elements: Iterable[A], asyncProcessing: A => Future[B], transform: Future[B] => Future[C])
-                                    (implicit ec: ExecutionContext): Future[Iterable[C]] = {
+  def parallelWithTransform[A, B, C](elements: Seq[A], asyncProcessing: A => Future[B], transform: Future[B] => Future[C])
+                                    (implicit ec: ExecutionContext): Future[Seq[C]] = {
     Future.sequence {
       for {
         e <- elements

--- a/commons-core/src/test/scala/com/wajam/commons/TestFutureUtils.scala
+++ b/commons-core/src/test/scala/com/wajam/commons/TestFutureUtils.scala
@@ -43,7 +43,7 @@ class TestFutureUtils extends FlatSpec with ShouldMatchers {
   it should behave like common(FutureUtils.parallel[Int, Int])
   it should behave like commonWithRecovery(FutureUtils.parallelWithRecovery[Int, Int])
 
-  private def common(f: (Iterable[Int], Int => Future[Int]) => Future[Iterable[Int]]) {
+  private def common(f: (Seq[Int], Int => Future[Int]) => Future[Iterable[Int]]) {
 
     it should "fail at first failure" in new Setup {
       val future = f(elements, delayedFuture(recorder, Some(numberToFailOn)))
@@ -60,7 +60,7 @@ class TestFutureUtils extends FlatSpec with ShouldMatchers {
     }
   }
 
-  private def commonWithRecovery(f: (Iterable[Int], Int => Future[Int]) => Future[Iterable[Try[Int]]]) {
+  private def commonWithRecovery(f: (Seq[Int], Int => Future[Int]) => Future[Iterable[Try[Int]]]) {
 
     it should "process all elements even if one fail" in new Setup {
       val future = f(elements, delayedFuture(recorder, Some(numberToFailOn)))


### PR DESCRIPTION
Using future with list of items to process independently is not obvious when you want to decide whether each item should be processed sequentially or in parallel (non-blocking in both cases). This small helper object makes it explicit.

Also, when processing a list of items and dealing with errors, should the processing stop (and fail the computation) on the first failure or should it do all it can and report the errors (using Either). This object support both versions.
