### PR TITLE
[COMMONS] Added the possibility to set the AsyncClient a name

### DIFF
--- a/commons-asyncclient/src/main/scala/com/wajam/asyncclient/AsyncClient.scala
+++ b/commons-asyncclient/src/main/scala/com/wajam/asyncclient/AsyncClient.scala
@@ -6,6 +6,7 @@ import com.ning.http.client
 
 import scala.language.implicitConversions
 import java.util.concurrent.{ExecutionException, Executors}
+import com.twitter.concurrent.NamedPoolThreadFactory
 
 trait BaseAsyncClient {
 
@@ -61,9 +62,12 @@ sealed trait Request {
   def params(paramList: Map[String, String]): Request
 }
 
-class AsyncClient(config: BaseHttpClientConfig) extends BaseAsyncClient {
+class AsyncClient(config: BaseHttpClientConfig, name: String) extends BaseAsyncClient {
 
-  private implicit val ec = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(config.threadPoolSize))
+  def this(config: BaseHttpClientConfig) = this(config, "async-client")
+
+  private implicit val ec = ExecutionContext.fromExecutorService(
+    Executors.newFixedThreadPool(config.threadPoolSize, new NamedPoolThreadFactory(name)))
 
   private val httpClient = Http.configure(_.
     setAllowPoolingConnection(config.allowPoolingConnection).

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -38,6 +38,7 @@ object CommonsBuild extends Build {
     "net.databinder.dispatch" %% "dispatch-lift-json" % "0.11.0" exclude("io.netty", "netty"),
     "io.netty" % "netty" % "3.5.0.Final",
     "org.json4s" %% "json4s-native" % "3.2.5",
+    "com.twitter" %% "util-core" % "6.1.0",
     "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2" % "it"
   )
 


### PR DESCRIPTION
 For the moment, this is used to name threads created in the thread pool.
