### PR TITLE
Tracing execution context

### DIFF
--- a/commons-tracing/src/main/scala/com/wajam/tracing/TracingExecutionContext.scala
+++ b/commons-tracing/src/main/scala/com/wajam/tracing/TracingExecutionContext.scala
@@ -1,0 +1,27 @@
+package com.wajam.tracing
+
+import scala.concurrent.ExecutionContext
+import com.wajam.commons.Logging
+
+/**
+ * Execution context decorator that saves the current tracing context when created and restore it every time
+ * it is executed.
+ */
+class TracingExecutionContext(ec: ExecutionContext) extends ExecutionContext with Logging {
+
+  val tracer = Tracer.currentTracer.get
+  val tracingContext = tracer.currentContext
+
+  def execute(runnable: Runnable) = {
+    ec.execute(new Runnable {
+      def run() {
+        tracer.trace(tracingContext) {
+          runnable.run()
+        }
+      }
+    })
+  }
+
+  def reportFailure(t: Throwable) = ec.reportFailure(t)
+}
+


### PR DESCRIPTION
Execution context decorator that saves the current tracing context when created and restore it every time it is executed.
