### PR TITLE
Removing RSIterator - Exception on empty ResultSet

### DIFF
--- a/commons-mysql/src/main/scala/com/wajam/mysql/MysqlDatabaseAccessor.scala
+++ b/commons-mysql/src/main/scala/com/wajam/mysql/MysqlDatabaseAccessor.scala
@@ -440,16 +440,5 @@ object MysqlDatabaseAccessor extends Logging {
     }
   }
 
-  class RsIterator(rs: ResultSet) extends Iterator[ResultSet] {
-
-    def hasNext: Boolean = !rs.isLast && !rs.isAfterLast
-
-    def next(): ResultSet = {
-      rs.next()
-      rs
-    }
-
-  }
-
   private val SELECT_MAX_TRY = 3
 }


### PR DESCRIPTION
Doesn't work with empty results... Until we found a working RSIterator with no side effect, it will be removed.
