### PR TITLE
Support optional hbase column family

### DIFF
--- a/commons-hbase/src/it/scala/com/wajam/commons/hbase/HBaseClientSpec.scala
+++ b/commons-hbase/src/it/scala/com/wajam/commons/hbase/HBaseClientSpec.scala
@@ -91,7 +91,6 @@ class HBaseClientSpec extends FlatSpec with BeforeAndAfterAll {
     store.getMultiFamiliesExtra(2) should be(None)
   }
 
-  // TODO: move to a specific schema test suite?
   it should "support adding extra families dynamically" in new Setup {
     val e_0 = MultiFamiliesEntity(0, value = "0", extra = Some(ExtraFamily("0", 0, Some("0"))))
     val e_1 = MultiFamiliesEntity(1, value = "1", extra = None)
@@ -126,6 +125,10 @@ class HBaseClientSpec extends FlatSpec with BeforeAndAfterAll {
     newStore.getMultiFamiliesExtra(2) should be(e_2.extra)
     newStore.getMultiFamiliesExtra(3) should be(e_3.extra)
     newStore.getMultiFamiliesExtra2(3) should be(e_3.extra2)
+
+    // saving without extra2 should not delete it because extra2 has deleteIfFamilyFieldMissing = false
+    newStore.saveMultiFamiliesEntity(e_0)
+    newStore.getMultiFamiliesEntity(0) should be(Some(e_0_extra2))
   }
 
   it should "fail to save extra families that are not case class" in new Setup {

--- a/commons-hbase/src/it/scala/com/wajam/commons/hbase/TestStore.scala
+++ b/commons-hbase/src/it/scala/com/wajam/commons/hbase/TestStore.scala
@@ -37,9 +37,8 @@ class TestStore(hbaseClient: HBaseClient, schema: TestSchema) {
 
   import com.wajam.commons.hbase.TestStore._
 
-  implicit val serializer = new HBaseJsonSerializer()
-    .withTypeHints(ShortTypeHints(List(classOf[PolymorphicEntity1], classOf[PolymorphicEntity2])))
-    .withTables(schema.tables)
+  implicit val serializer = HBaseJsonSerializer(
+    ShortTypeHints(List(classOf[PolymorphicEntity1], classOf[PolymorphicEntity2])), schema.tables)
 
   // CompoundEntity operations
 

--- a/commons-hbase/src/it/scala/com/wajam/commons/hbase/TestStore.scala
+++ b/commons-hbase/src/it/scala/com/wajam/commons/hbase/TestStore.scala
@@ -28,7 +28,7 @@ class TestSchema(namespace: String, admin: HBaseAdmin) extends HBaseSchema(admin
 
     new TestSchema(namespace, admin) {
       override val testMultiFamiliesTable: Table = Table(_testMultiFamiliesTable.name,
-        Family("extra2", SnappyCompression) :: _testMultiFamiliesTable.families)
+        Family("extra2", SnappyCompression, deleteIfFamilyFieldMissing = false) :: _testMultiFamiliesTable.families)
     }
   }
 }
@@ -37,14 +37,9 @@ class TestStore(hbaseClient: HBaseClient, schema: TestSchema) {
 
   import com.wajam.commons.hbase.TestStore._
 
-  implicit val serializer = new HBaseJsonSerializer {
-    override def typeHints = ShortTypeHints(List(
-      classOf[PolymorphicEntity1],
-      classOf[PolymorphicEntity2]))
-
-    override def tablesColumnsFamilies = schema.tables.map(table =>
-      table.name -> table.families.filter(_.name != "base").map(_.name).toSet).toMap
-  }
+  implicit val serializer = new HBaseJsonSerializer()
+    .withTypeHints(ShortTypeHints(List(classOf[PolymorphicEntity1], classOf[PolymorphicEntity2])))
+    .withTables(schema.tables)
 
   // CompoundEntity operations
 

--- a/commons-hbase/src/main/scala/com/wajam/commons/hbase/HBaseSchema.scala
+++ b/commons-hbase/src/main/scala/com/wajam/commons/hbase/HBaseSchema.scala
@@ -85,7 +85,7 @@ object HBaseSchema {
 
   case object NoCompression extends FamilyCompression
 
-  case class Family(name: String, compression: FamilyCompression = NoCompression) {
+  case class Family(name: String, compression: FamilyCompression = NoCompression, deleteIfFamilyFieldMissing: Boolean = true) {
     def toDescriptor: HColumnDescriptor = {
       val descriptor = new HColumnDescriptor(name)
       compression match {

--- a/commons-hbase/src/main/scala/com/wajam/commons/hbase/HBaseSerializer.scala
+++ b/commons-hbase/src/main/scala/com/wajam/commons/hbase/HBaseSerializer.scala
@@ -17,52 +17,13 @@ trait HBaseSerializer {
 
 }
 
-class HBaseJsonSerializer(defaultColumnFamily: String = "base",
-                          extraFormatSerializers: Traversable[Serializer[_]] = Nil) extends HBaseSerializer {
+import com.wajam.commons.hbase.HBaseJsonSerializer._
 
-  val STRING_BYTE = 's'.toByte
-  val INT_BYTE = 'i'.toByte
-  val DOUBLE_BYTE = 'd'.toByte
-  val BOOL_BYTE = 'b'.toByte
-  val OBJECT_BYTE = 'o'.toByte
-  val LIST_BYTE = 'l'.toByte
-  val DATE_BYTE = 't'.toByte
-  val DATE_STR = DATE_BYTE.toString
-
-  private[hbase] def typeHints: TypeHints = NoTypeHints
-
-  private[hbase] def tablesColumnsFamilies: Map[TableName, Iterable[HBaseSchema.Family]] = Map()
-
-  /**
-   * Serializer with given <code>TypeHint</code>s. Useful to support persistence of polymorphic objects.
-   * Example: if we have a Doc and Cat class that inherits Animal, we need to hint that
-   * we may use them in a polymorphic way.
-   * <p>
-   * Usage: <code>serializer.withTypeHints(ShortTypeHints(List(classOf[Dog], classOf[Cat])))</code>
-   */
-  def withTypeHints(hints: TypeHints): HBaseJsonSerializer = {
-    val families = tablesColumnsFamilies
-    new HBaseJsonSerializer(defaultColumnFamily, extraFormatSerializers) {
-      override private[hbase] val typeHints = hints
-      override private[hbase] val tablesColumnsFamilies = families
-    }
-  }
-
-  /**
-   * Serializer with tables having "special" column families.
-   */
-  def withTables(tables: Iterable[HBaseSchema.Table]): HBaseJsonSerializer = {
-    val hints = typeHints
-    new HBaseJsonSerializer(defaultColumnFamily, extraFormatSerializers) {
-      override private[hbase] val typeHints = hints
-      override private[hbase] val tablesColumnsFamilies = tables.flatMap { table =>
-        table.families.filter(_.name != defaultColumnFamily) match {
-          case Nil => None
-          case families => Some(table.name -> families)
-        }
-      }.toMap
-    }
-  }
+class HBaseJsonSerializer(mainColumnFamily: String = DefaultColumnFamily,
+                          typeHints: TypeHints = NoTypeHints,
+                          extraColumnsFamilies: Map[TableName, Iterable[HBaseSchema.Family]] = Map(),
+                          extraFormatSerializers: Traversable[Serializer[_]] = Nil)
+    extends HBaseSerializer {
 
   private object DateTimeSerializer extends Serializer[DateTime] {
     val isoDateFormat = ISODateTimeFormat.dateTime()
@@ -85,33 +46,33 @@ class HBaseJsonSerializer(defaultColumnFamily: String = "base",
     case (field, _) if field.contains("$") => None // This ignore private fields
   }, PartialFunction.empty)
 
-  private implicit lazy val formats = DefaultFormats.withHints(typeHints) + DateTimeSerializer ++ extraFormatSerializers + NoneJNothingSerializer
+  implicit val formats = DefaultFormats.withHints(typeHints) + DateTimeSerializer ++ extraFormatSerializers + NoneJNothingSerializer
 
   private def getColumnFamilyObject(table: TableName, columnFamily: String): Option[HBaseSchema.Family] = {
-    tablesColumnsFamilies.get(table).flatMap(_.find(_.name == columnFamily))
+    extraColumnsFamilies.get(table).flatMap(_.find(_.name == columnFamily))
   }
 
   private def fromJValue(v: JValue): Array[Byte] = v match {
-    case JInt(i) => (List(INT_BYTE) ++ BigIntValueConverter.toBytes(i)).toArray
-    case JString(s) => (List(STRING_BYTE) ++ StringValueConverter.toBytes(s)).toArray
-    case JDouble(d) => (List(DOUBLE_BYTE) ++ DoubleValueConverter.toBytes(d)).toArray
-    case JBool(b) => (List(BOOL_BYTE) ++ BooleanValueConverter.toBytes(b)).toArray
-    case JObject(o) => (List(OBJECT_BYTE) ++ StringValueConverter.toBytes(Serialization.write(v))).toArray
-    case JArray(List(JString("date"), JString(s))) => (List(DATE_BYTE) ++ StringValueConverter.toBytes(s)).toArray
-    case JArray(o) => (List(LIST_BYTE) ++ StringValueConverter.toBytes(Serialization.write(v))).toArray
+    case JInt(i) => (List(IntByte) ++ BigIntValueConverter.toBytes(i)).toArray
+    case JString(s) => (List(StringByte) ++ StringValueConverter.toBytes(s)).toArray
+    case JDouble(d) => (List(DoubleByte) ++ DoubleValueConverter.toBytes(d)).toArray
+    case JBool(b) => (List(BoolByte) ++ BooleanValueConverter.toBytes(b)).toArray
+    case JObject(o) => (List(ObjectByte) ++ StringValueConverter.toBytes(Serialization.write(v))).toArray
+    case JArray(List(JString("date"), JString(s))) => (List(DateByte) ++ StringValueConverter.toBytes(s)).toArray
+    case JArray(o) => (List(ListByte) ++ StringValueConverter.toBytes(Serialization.write(v))).toArray
     case JNothing => null
     case JNull => null
     case _ => throw new Exception(s"Unsupported JSON type: $v (type ${v.getClass}")
   }
 
   private def fromBytes(bytes: Array[Byte]): JValue = if (bytes != null && bytes.size > 0) bytes(0) match {
-    case INT_BYTE => JInt(BigIntValueConverter.fromBytes(bytes.slice(1, bytes.size)))
-    case STRING_BYTE => JString(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))
-    case DOUBLE_BYTE => JDouble(DoubleValueConverter.fromBytes(bytes.slice(1, bytes.size)))
-    case BOOL_BYTE => JBool(BooleanValueConverter.fromBytes(bytes.slice(1, bytes.size)))
-    case DATE_BYTE => JArray(List(JString("date"), JString(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))))
-    case OBJECT_BYTE => parse(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))
-    case LIST_BYTE => parse(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))
+    case IntByte => JInt(BigIntValueConverter.fromBytes(bytes.slice(1, bytes.size)))
+    case StringByte => JString(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))
+    case DoubleByte => JDouble(DoubleValueConverter.fromBytes(bytes.slice(1, bytes.size)))
+    case BoolByte => JBool(BooleanValueConverter.fromBytes(bytes.slice(1, bytes.size)))
+    case DateByte => JArray(List(JString("date"), JString(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))))
+    case ObjectByte => parse(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))
+    case ListByte => parse(StringValueConverter.fromBytes(bytes.slice(1, bytes.size)))
   }
   else JNothing
 
@@ -130,26 +91,61 @@ class HBaseJsonSerializer(defaultColumnFamily: String = "base",
         case field @ JField(name, value) => (value, getColumnFamilyObject(table, name)) match {
           case (uo: JObject, Some(_)) => uo.obj.foreach(mutateField(name, _))
           case (JNothing, Some(family)) if family.deleteIfFamilyFieldMissing => mutations.deleteFamily(name)
-          case (JNothing, Some(_)) => // No action on column family
-          case (_, None) => mutateField(defaultColumnFamily, field)
+          case (JNothing, Some(_)) => // No action on extra column family
+          case (_, None) => mutateField(mainColumnFamily, field)
           case _ => throw new Exception(s"Cannot serialize extra family '$name' value : $value (type ${value.getClass})")
         }
-        case field => mutateField(defaultColumnFamily, field)
+        case field => mutateField(mainColumnFamily, field)
       }
       case o => throw new Exception(s"Cannot serialize object: $o (type ${o.getClass})")
     }
   }
 
   def deserialize[A](table: TableName, result: WrappedResult)(implicit mf: Manifest[A]): A = {
-    val fields = (result.columns(defaultColumnFamily).map((colName: String) =>
-      JField(colName, fromBytes(result.get(defaultColumnFamily, colName)))) ++
+    val fields = (result.columns(mainColumnFamily).map((colName: String) =>
+      JField(colName, fromBytes(result.get(mainColumnFamily, colName)))) ++
       result.families.flatMap {
-        case family if family == defaultColumnFamily => None
+        case family if family == mainColumnFamily => None
         case family if getColumnFamilyObject(table, family).isDefined => Some(JField(family, JObject(result.columns(family).map((colName: String) =>
           JField(colName, fromBytes(result.get(family, colName)))).toList)))
       }).toList
 
     JObject(fields).extract[A]
+  }
+
+}
+
+object HBaseJsonSerializer {
+
+  val DefaultColumnFamily = "base"
+
+  val StringByte = 's'.toByte
+  val IntByte = 'i'.toByte
+  val DoubleByte = 'd'.toByte
+  val BoolByte = 'b'.toByte
+  val ObjectByte = 'o'.toByte
+  val ListByte = 'l'.toByte
+  val DateByte = 't'.toByte
+
+  def apply(typeHints: TypeHints, tables: Iterable[HBaseSchema.Table]): HBaseJsonSerializer = {
+    HBaseJsonSerializer(mainColumnFamily = DefaultColumnFamily, typeHints, tables, extraFormatSerializers = Nil)
+  }
+
+  def apply(typeHints: TypeHints, tables: Iterable[HBaseSchema.Table],
+            extraFormatSerializers: Traversable[Serializer[_]]): HBaseJsonSerializer = {
+    HBaseJsonSerializer(mainColumnFamily = DefaultColumnFamily, typeHints, tables, extraFormatSerializers)
+  }
+
+  def apply(mainColumnFamily: String, typeHints: TypeHints, tables: Iterable[HBaseSchema.Table],
+            extraFormatSerializers: Traversable[Serializer[_]]): HBaseJsonSerializer = {
+    val tablesColumnsFamilies = tables.flatMap { table =>
+      table.families.filter(_.name != mainColumnFamily) match {
+        case Nil => None
+        case families => Some(table.name -> families)
+      }
+    }.toMap
+
+    new HBaseJsonSerializer(mainColumnFamily, typeHints, tablesColumnsFamilies, extraFormatSerializers)
   }
 
 }

--- a/project/CommonsBuild.scala
+++ b/project/CommonsBuild.scala
@@ -44,7 +44,7 @@ object CommonsBuild extends Build {
   )
 
   lazy val hbaseDeps = Seq(
-    "com.github.nscala-time" %% "nscala-time" % "0.4.0",
+    "com.github.nscala-time" %% "nscala-time" % "1.0.0",
     "io.netty" % "netty" % "3.6.6.Final",
     "org.json4s" %% "json4s-native" % "3.2.5",
     "org.apache.hadoop" % "hadoop-client" % "2.3.0-cdh5.1.0" exclude("io.netty", "netty"),


### PR DESCRIPTION
Can control if saving an object with a missing column family object delete or not the underlying family in hbase. Controled by Family.deleteIfFamilyFieldMissing flag in HBaseSchema.